### PR TITLE
Add IDs to events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codo-theme-sm",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "SaleMove Codo theme",
   "main": "index.js",
   "scripts": {

--- a/templates/partials/documentation.hamlc
+++ b/templates/partials/documentation.hamlc
@@ -79,7 +79,7 @@
       .events
         %h3 Events:
         - for event in @documentation.events
-          .event
+          .event{ id: "#{event.name}-event" }
             %p.signature
               = event.name
             != @render('partials/documentation', documentation: event.documentation)


### PR DESCRIPTION
This allows linking to these events from the rest of the documentation.